### PR TITLE
Fetch server improvements

### DIFF
--- a/lib/fetch-server.js
+++ b/lib/fetch-server.js
@@ -1,4 +1,5 @@
 import isFunction from 'lodash/isFunction';
+import isString from 'lodash/isString';
 import * as sinon from 'sinon';
 
 /**
@@ -42,8 +43,19 @@ export class FetchServer {
     for (const [route, handler] of routes) {
       if (url.includes(route)) {
         if (params && params.body) {
-          params = JSON.parse(params.body);
+          if (isString(params.body)) {
+            // Allow string or JSON params.body; if valid JSON,
+            // parse body to JS object before passing to handler function.
+            try {
+              params = JSON.parse(params.body);
+            } catch (err) {
+              params = params.body;
+            }
+          } else {
+            throw new Error(`Invalid body: ${params.body}`);
+          }
         }
+
         let response = isFunction(handler) ? handler(url, params) : handler;
 
         // Not yet promise-like

--- a/lib/fetch-server.js
+++ b/lib/fetch-server.js
@@ -18,6 +18,14 @@ import * as sinon from 'sinon';
  * const val = await res.json(); // 'bar'
  */
 export class FetchServer {
+
+  /**
+   * Create a FetchServer instance.
+   *
+   * @param {object} handlers : map of urls to response objects (or functions)
+   * @param {object} [options={}]
+   * @param {boolean} [options.debug=false] : output debug logging to console
+   */
   constructor(handlers, {debug = false} = {}) {
     this.handlers = handlers;
     this.debug = debug;
@@ -79,11 +87,48 @@ export class FetchServer {
     throw new Error(`Unexpected fetch: ${url} params: ${JSON.stringify(params)}`);
   }
 
+  /**
+   * Start the FetchServer, sinon.stub'ing `fetch` with a fake version.
+   */
   start() {
-    if (window.fetch.hasOwnProperty(`restore`)) {
+    this.restore(); // clean up prior FetchServer stubs (if necessary)
+
+    // stub fetch in browser environment:
+    if (typeof window !== `undefined` && window.fetch) {
+      sinon.stub(window, `fetch`).callsFake(this.handle);
+    }
+    // stub fetch in NodeJS environment:
+    if (typeof global !== `undefined` && global.fetch) {
+      sinon.stub(global, `fetch`).callsFake(this.handle);
+    }
+  }
+
+  /**
+   * Restore sinon.stub'ed `fetch` to its original state.
+   */
+  static restore() {
+    // restore fetch in browser environment:
+    if (
+      typeof window !== `undefined` && window.fetch &&
+      Object.hasOwnProperty.call(window.fetch, `restore`)
+    ) {
       window.fetch.restore();
     }
-    sinon.stub(window, `fetch`).callsFake(this.handle);
+    // restore fetch in NodeJS environment:
+    if (
+      typeof global !== `undefined` && global.fetch &&
+      Object.hasOwnProperty.call(global.fetch, `restore`)
+    ) {
+      global.fetch.restore();
+    }
+  }
+
+  /**
+   * Restore sinon.stub'ed `fetch` to its original state.
+   * (convenience method for calling from class instance)
+   */
+  restore() {
+    FetchServer.restore();
   }
 
   debugLog({url, params, response}) {

--- a/lib/fetch-server.js
+++ b/lib/fetch-server.js
@@ -24,8 +24,22 @@ export class FetchServer {
   }
 
   handle(url, params) {
-    for (const [route, handler] of Object.entries(this.handlers)) {
+    // Order routes by url length (descending).
+    // This ensures that when route overlap occurs (e.g. /foo/bar and /foo/bar/baz)
+    // the more-specific route (/foo/bar/baz) is checked first. Otherwise, some
+    // routes will be silently ignored when more-generic (shorter) routes exist.
+    const routes = Object.entries(this.handlers).sort(([aRoute], [bRoute]) => {
+      // If route lengths are the same, sort alphabetically;
+      // otherwise, sort by route string length (descending).
+      // Route length + alpha makes sort fully deterministic.
+      if (bRoute.length === aRoute.length) {
+        return bRoute.toLowerCase() < aRoute.toLowerCase() ? 1 : -1;
+      } else {
+        return bRoute.length - aRoute.length;
+      }
+    });
 
+    for (const [route, handler] of routes) {
       if (url.includes(route)) {
         if (params && params.body) {
           params = JSON.parse(params.body);

--- a/lib/fetch-server.js
+++ b/lib/fetch-server.js
@@ -25,11 +25,15 @@ export class FetchServer {
    * @param {object} handlers : map of urls to response objects (or functions)
    * @param {object} [options={}]
    * @param {boolean} [options.debug=false] : output debug logging to console
+   * @param {function|null} [options.errorCallback=null] : custom error handler
+   *
+   * errorCallback param allows hooking test framework error handling utils
+   * into FetchServer so that tests may be reliably failed on error.
    */
-  constructor(handlers, {debug = false} = {}) {
+  constructor(handlers, {debug = false, errorCallback = null} = {}) {
     this.handlers = handlers;
     this.debug = debug;
-    this.handle = this.handle.bind(this);
+    this.errorCallback = errorCallback;
   }
 
   handle(url, params) {
@@ -93,13 +97,24 @@ export class FetchServer {
   start() {
     this.restore(); // clean up prior FetchServer stubs (if necessary)
 
+    const fakeFetch = (url, params) => {
+      try {
+        return this.handle(url, params);
+      } catch (err) {
+        // errorCallback allows hooking test framework error handling utils
+        // into FetchServer so that tests may be reliably failed on error:
+        isFunction(this.errorCallback) && this.errorCallback(err);
+        throw err; // rethrow error
+      }
+    };
+
     // stub fetch in browser environment:
     if (typeof window !== `undefined` && window.fetch) {
-      sinon.stub(window, `fetch`).callsFake(this.handle);
+      sinon.stub(window, `fetch`).callsFake(fakeFetch);
     }
     // stub fetch in NodeJS environment:
     if (typeof global !== `undefined` && global.fetch) {
-      sinon.stub(global, `fetch`).callsFake(this.handle);
+      sinon.stub(global, `fetch`).callsFake(fakeFetch);
     }
   }
 


### PR DESCRIPTION
A handful of small improvements to replace hacks that we've added in our app test code. Credit to @junhouse for spelunking down a serious debugging rabbit-hole which led to the overlapping-route fix.
- 6475757 `fix overlapping route issue: always check more-specific routes first`
  - This addresses an issue that's been a recurring source of confusion while managing fetch mocking in our tests. If you define a url `/foo` in some "base" handlers object, and then you compose other more specific handers into that object adding something like `/foo/bar/baz`, the latter will never be matched because the `url.includes` matching used by FetchServer always matches `/foo` instead. Basically, routes that include other routes lead to confusing behavior and the problem is exacerbated the heavy amount of composition we use to create handlers in our tests.
  - A more flexible fix would be full regex-based url matching instead of `String.includes`, but for now this minimal fix orders routes by length (descending) before matching, so that "more specific" urls will always be matched before "less specific" urls and order of matching is deterministic (url length + alpha).
- ae9d005 `allow string params.body without throwing JSON parse error`
  - We need to mock some endpoints that expect a non-JSON-parseable body in the response; FetchServer doesn't currently accommodate this and throws a `SyntaxError`. This change allows any string body, and will attempt to JSON-parse before passing the body on as-is.
- a0f8f43 `stub global.fetch for NodeJS; add FetchServer.restore; add docs`
  - This stubs `global.fetch` (in addition to `window.fetch`) if tests are running in a NodeJS environment.
  - It also adds a `FetchServer.restore` function that can be used to restore `global/window.fetch` to its original state.
- 74132bc `add errorCallback param for hooking in Mocha to reliably fail tests on error`
  - We've run into issues where errors originating from FetchServer (mainly `Unexpected fetch`) don't actually fail our tests because they're occurring under layers of async code and Mocha can't detect promise rejection correctly in all cases. This provides an optional error callback function that allows us to hook Mocha's error handler in to reliably fail tests on any error coming from FetchServer.