### PR TITLE
Fetch server bugfix

### DIFF
--- a/lib/fetch-server.js
+++ b/lib/fetch-server.js
@@ -95,8 +95,6 @@ export class FetchServer {
    * Start the FetchServer, sinon.stub'ing `fetch` with a fake version.
    */
   start() {
-    this.restore(); // clean up prior FetchServer stubs (if necessary)
-
     const fakeFetch = (url, params) => {
       try {
         return this.handle(url, params);
@@ -108,12 +106,20 @@ export class FetchServer {
       }
     };
 
+    this.restore(); // clean up prior FetchServer stubs (if necessary)
+
     // stub fetch in browser environment:
-    if (typeof window !== `undefined` && window.fetch) {
+    if (
+      typeof window !== `undefined` && window.fetch &&
+      !Object.hasOwnProperty.call(window.fetch, `restore`)
+    ) {
       sinon.stub(window, `fetch`).callsFake(fakeFetch);
     }
     // stub fetch in NodeJS environment:
-    if (typeof global !== `undefined` && global.fetch) {
+    if (
+      typeof global !== `undefined` && global.fetch &&
+      !Object.hasOwnProperty.call(global.fetch, `restore`)
+    ) {
       sinon.stub(global, `fetch`).callsFake(fakeFetch);
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "domsuite",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "domsuite",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Browser testing/automation utilities with async/await",
   "main": "lib/index.js",
   "files": [


### PR DESCRIPTION
Generally in a browser environment `global.fetch` isn't defined, but in some of our integration tests it is (along with `window.fetch`). This condition was missed in the earlier FetchServer changeset - add checks to handle this gracefully.